### PR TITLE
support strictUndefinedChecks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,11 +50,7 @@ export default Prisma.defineExtension(
                     ...findManyArgs,
                     take,
                     skip: cursorValue ? 1 : 0,
-                    cursor: cursorValue
-                      ? {
-                          [cursorField]: cursorValue,
-                        }
-                      : undefined,
+                    ...(cursorValue ? { cursor: { [cursorField]: cursorValue } } : {}),
                   });
                   const transformedResults = batchTransformer
                     ? await batchTransformer(results)


### PR DESCRIPTION
Prisma [`strictUndefinedChecks`](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/null-and-undefined) will throw if `cursor` is explicitly `undefined` but since `Prisma.skip` is only available when the previewFeature is active, it's safer and backward compatible to only add `cursor` when it is defined