### PR TITLE
feat: add cursor field option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following options (passed as a second argument) provide additional controls 
 - **Batch size**: `batchSize` specifies how many rows are fetched each batch. Defaults to `100`
 - **Pre-fill size**: Since the streaming happens asynchronously, it may be useful to fetch more rows well before current batch is completely consumed. `prefill` specifies the internal `highWaterMark` of the `Readable` stream. Defaults to double the batch size (usually `200`).
 - **Batch transformation**: Sometimes you may need to pre-process the resulting rows in batches before they are consumed. This is where the `batchTransformer` comes in. If provided, it receives an array of the last fetched batch of rows, can operate on them asynchronously, and then return an array of transformed rows to be consumed instead. Types are properly handled.
+- **Cursor field**: `cursor` Specifies the model field to be used as the cursor.
 
 ```js
 const stream = db.post.cursorStream(
@@ -81,6 +82,7 @@ const stream = db.post.cursorStream(
         translatedTitle: translations[i],
       }));
     },
+    cursor: 'another_id'
   }
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,11 @@ export default Prisma.defineExtension(
           >(
             this: T,
             findManyArgs: A,
-            { batchSize, prefill, batchTransformer } = {} as {
+            { batchSize, prefill, batchTransformer, cursor } = {} as {
               batchSize?: number;
               prefill?: number;
               batchTransformer?: C;
+              cursor?: Extract<keyof R, string> | undefined;
             }
           ): AsyncIterable<
             C extends Function
@@ -33,7 +34,7 @@ export default Prisma.defineExtension(
 
             const take = batchSize || 100;
             const highWaterMark = prefill || take * 2;
-            const cursorField =
+            const cursorField = cursor ||
               Object.keys(findManyArgs.cursor || {})[0] || "id";
 
             if (findManyArgs.select && !findManyArgs.select[cursorField]) {


### PR DESCRIPTION
This will allow you to set a different field for the cursor without passing the cursor in the payload.

Thanks for the help and the identification of the problem to Artyom Badalyan @a-badalyan

Also looks like PR resolves issues https://github.com/etabits/prisma-cursorstream/issues/4